### PR TITLE
Genesis records database storing speed improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "near-actix-utils"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix",
 ]
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "borsh",
  "cached",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "chrono",
  "derive_more",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix",
  "borsh",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix",
  "ansi_term",
@@ -1862,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "arrayref",
  "blake2",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "borsh",
  "cached",
@@ -1907,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix",
  "futures",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix",
  "actix-cors",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix-web",
  "futures",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "lazy_static",
  "log",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix",
  "borsh",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -2031,7 +2031,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "base64",
  "borsh",
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "near-primitives",
  "near-runtime-fees",
@@ -2096,8 +2096,8 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "1.0.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+version = "1.1.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "num-rational",
  "serde",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "near-store"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2128,7 +2128,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix",
  "actix-web",
@@ -2142,8 +2142,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "1.0.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+version = "1.1.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "borsh",
  "near-rpc-error-macro",
@@ -2152,8 +2152,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "1.0.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+version = "1.1.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "base64",
  "bs58",
@@ -2167,8 +2167,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.0.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+version = "1.1.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "cached",
  "near-runtime-fees",
@@ -2183,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "neard"
 version = "1.2.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "actix",
  "actix-web",
@@ -2247,8 +2247,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.0.0"
-source = "git+https://github.com/nearprotocol/nearcore#7d7ab4769e3fd2e3019806b3e727c2343ac793e3"
+version = "1.1.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=f80c12792669af633fbb925e253452ae693e33d5#f80c12792669af633fbb925e253452ae693e33d5"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2271,8 +2271,6 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "sha2",
- "sha3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,8 +894,7 @@ dependencies = [
 [[package]]
 name = "diesel-derive-enum"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703e71c268ea2d8da9c0ab0b40d8b217179ee622209c170875d24443193a0dfb"
+source = "git+https://github.com/khorolets/diesel-derive-enum.git?branch=lookup-hack#f15b35927291d1e3be725fb2321da6edb91704aa"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1474,6 +1473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,12 +1928,15 @@ dependencies = [
  "diesel",
  "diesel-derive-enum",
  "dotenv",
+ "futures",
+ "itertools",
  "near-indexer",
  "r2d2",
  "serde_json",
  "tokio",
  "tokio-diesel",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ tokio-diesel = "0.3.0"
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/nearprotocol/nearcore" }
+near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="f80c12792669af633fbb925e253452ae693e33d5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,17 @@ edition = "2018"
 [dependencies]
 actix = "0.9"
 bigdecimal = "0.1.0"
-diesel = { version = "1.4.4", features = ["postgres", "numeric", "serde_json"] }
-diesel-derive-enum = { version = "1", features = ["postgres"] }
+diesel = { version = "1.4.5", features = ["postgres", "numeric", "serde_json"] }
+# Using hacky diesel-derive-enum https://github.com/adwhit/diesel-derive-enum/issues/52
+diesel-derive-enum = { git = "https://github.com/khorolets/diesel-derive-enum.git", branch = "lookup-hack", features = ["postgres"] }
+futures = "0.3.5"
+itertools = "0.9.0"
 dotenv = "0.15.0"
 r2d2 = "0.8.8"
 serde_json = "1.0.55"
 tokio = { version = "0.2", features = ["sync", "time"] }
 tokio-diesel = "0.3.0"
 tracing = "0.1.13"
+tracing-subscriber = "0.2.4"
 
 near-indexer = { git = "https://github.com/nearprotocol/nearcore" }

--- a/diesel.toml
+++ b/diesel.toml
@@ -4,4 +4,4 @@
 [print_schema]
 file = "src/schema.rs"
 import_types = ["diesel::sql_types::*", "crate::db::enums::*"]
-filter = { except_tables = ["spatial_ref_sys"] }
+filter = { only_tables = ["access_keys"] }

--- a/diesel.toml
+++ b/diesel.toml
@@ -4,3 +4,4 @@
 [print_schema]
 file = "src/schema.rs"
 import_types = ["diesel::sql_types::*", "crate::db::enums::*"]
+filter = { except_tables = ["spatial_ref_sys"] }

--- a/src/db/access_keys.rs
+++ b/src/db/access_keys.rs
@@ -3,7 +3,7 @@ use crate::schema;
 use bigdecimal::BigDecimal;
 use schema::access_keys;
 
-#[derive(Insertable, Queryable)]
+#[derive(Insertable, Queryable, Clone)]
 pub(crate) struct AccessKey {
     pub public_key: String,
     pub account_id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,7 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) 
                         .flatten()
                         .collect::<Vec<AccessKey>>(),
                 )
+                .on_conflict_do_nothing()
                 .execute_async(&pool)
                 .await
                 .unwrap();
@@ -192,7 +193,9 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) 
 }
 
 fn main() {
-    let env_filter = EnvFilter::new("tokio_reactor=info,near=info,near=error,stats=info,telemetry=info,indexer_for_wallet=info");
+    let env_filter = EnvFilter::new(
+        "tokio_reactor=info,near=info,near=error,stats=info,telemetry=info,indexer_for_wallet=info",
+    );
     tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(env_filter)
         .with_writer(std::io::stderr)

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) 
 }
 
 fn main() {
-    let env_filter = EnvFilter::new("tokio_reactor=info,near=info,near=error,stats=info,telemetry=info,indexer_for_wallet=error,indexer_for_wallet=info");
+    let env_filter = EnvFilter::new("tokio_reactor=info,near=info,near=error,stats=info,telemetry=info,indexer_for_wallet=info");
     tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(env_filter)
         .with_writer(std::io::stderr)

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,12 +64,7 @@ async fn handle_genesis_public_keys(near_config: near_indexer::NearConfig) {
         });
 
     let chunk_size = 5000;
-    let total_access_key_chunks = access_keys.clone().count() / chunk_size;
-    let total_access_key_chunks = if total_access_key_chunks > 0 {
-        total_access_key_chunks
-    } else {
-        1
-    };
+    let total_access_key_chunks = access_keys.clone().count() / chunk_size + 1;
     let slice = access_keys.chunks(chunk_size);
 
     let insert_genesis_keys: futures::stream::FuturesUnordered<_> = slice

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,13 @@ use dotenv::dotenv;
 extern crate diesel;
 use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::{ExpressionMethods, PgConnection, QueryDsl};
+use futures::stream::StreamExt;
+use itertools::Itertools;
 use tokio::sync::mpsc;
 use tokio::time;
 use tokio_diesel::AsyncRunQueryDsl;
-use tracing::error;
+use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
 
 use crate::db::enums::{ActionEnum, StatusEnum};
 use crate::db::AccessKey;
@@ -18,6 +21,7 @@ mod db;
 mod schema;
 
 const INTERVAL: Duration = Duration::from_millis(100);
+const INDEXER_FOR_WALLET: &str = "indexer_for_wallet";
 
 fn establish_connection() -> Pool<ConnectionManager<PgConnection>> {
     dotenv().ok();
@@ -57,15 +61,47 @@ async fn handle_genesis_public_keys(near_config: near_indexer::NearConfig) {
             } else {
                 None
             }
-        })
-        .collect::<Vec<AccessKey>>();
+        });
 
-    diesel::insert_into(schema::access_keys::table)
-        .values(access_keys)
-        .on_conflict_do_nothing()
-        .execute_async(&pool)
-        .await
-        .unwrap();
+    let chunk_size = 5000;
+    let total_access_key_chunks = access_keys.clone().count() / chunk_size;
+    let total_access_key_chunks = if total_access_key_chunks > 0 {
+        total_access_key_chunks
+    } else {
+        1
+    };
+    let slice = access_keys.chunks(chunk_size);
+
+    let insert_genesis_keys: futures::stream::FuturesUnordered<_> = slice
+        .into_iter()
+        .map(|keys| async {
+            let collected_keys = keys.collect::<Vec<AccessKey>>();
+            loop {
+                match diesel::insert_into(schema::access_keys::table)
+                    .values(collected_keys.clone())
+                    .on_conflict_do_nothing()
+                    .execute_async(&pool).await {
+                        Ok(result) => break result,
+                        Err(err) => {
+                            info!(target: INDEXER_FOR_WALLET, "Trying to push genesis access keys failed with: {:?}. Retrying in {} seconds...", err, INTERVAL.as_secs_f32());
+                            time::delay_for(INTERVAL).await;
+                        }
+                    }
+                }
+            })
+        .collect();
+
+    let mut insert_genesis_keys = insert_genesis_keys.enumerate();
+
+    while let Some((index, _result)) = insert_genesis_keys.next().await {
+        info!(
+            target: INDEXER_FOR_WALLET,
+            "Genesis public keys adding {}%",
+            index * 100 / total_access_key_chunks
+        );
+    }
+
+    info!(target: INDEXER_FOR_WALLET, "Genesis public keys handled.");
 }
 
 async fn update_receipt_status(
@@ -101,6 +137,30 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) 
     while let Some(block) = stream.recv().await {
         eprintln!("Block height {:?}", block.block.header.height);
 
+        // Handle receipts
+        for chunk in &block.chunks {
+            diesel::insert_into(schema::access_keys::table)
+                .values(
+                    chunk
+                        .receipts
+                        .iter()
+                        .filter_map(|receipt| match receipt.receipt {
+                            near_indexer::near_primitives::views::ReceiptEnumView::Action {
+                                ..
+                            } => Some(AccessKey::from_receipt_view(
+                                receipt,
+                                block.block.header.height,
+                            )),
+                            _ => None,
+                        })
+                        .flatten()
+                        .collect::<Vec<AccessKey>>(),
+                )
+                .execute_async(&pool)
+                .await
+                .unwrap();
+        }
+
         // Handle outcomes
         let receipt_outcomes = &block
             .outcomes
@@ -133,34 +193,21 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) 
             })
             .collect::<Vec<String>>();
         update_receipt_status(succeeded_receipt_ids, StatusEnum::Success, &pool).await;
-
-        // Handle receipts
-        for chunk in &block.chunks {
-            diesel::insert_into(schema::access_keys::table)
-                .values(
-                    chunk
-                        .receipts
-                        .iter()
-                        .filter_map(|receipt| match receipt.receipt {
-                            near_indexer::near_primitives::views::ReceiptEnumView::Action {
-                                ..
-                            } => Some(AccessKey::from_receipt_view(
-                                receipt,
-                                block.block.header.height,
-                            )),
-                            _ => None,
-                        })
-                        .flatten()
-                        .collect::<Vec<AccessKey>>(),
-                )
-                .execute_async(&pool)
-                .await
-                .unwrap();
-        }
     }
 }
 
 fn main() {
+    let env_filter = EnvFilter::new("tokio_reactor=info,near=info,near=error,stats=info,telemetry=info,indexer_for_wallet=error,indexer_for_wallet=info");
+    tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr)
+        .init();
+
+    info!(
+        target: INDEXER_FOR_WALLET,
+        "NEAR Indexer for Wallet started."
+    );
+
     let home_dir: Option<String> = env::args().nth(1);
 
     let indexer = near_indexer::Indexer::new(home_dir.as_ref().map(AsRef::as_ref));

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -12,3 +12,18 @@ table! {
         permission -> Permission_type,
     }
 }
+
+table! {
+    use diesel::sql_types::*;
+    use crate::db::enums::*;
+
+    spatial_ref_sys (srid) {
+        srid -> Int4,
+        auth_name -> Nullable<Varchar>,
+        auth_srid -> Nullable<Int4>,
+        srtext -> Nullable<Varchar>,
+        proj4text -> Nullable<Varchar>,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(access_keys, spatial_ref_sys,);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -12,18 +12,3 @@ table! {
         permission -> Permission_type,
     }
 }
-
-table! {
-    use diesel::sql_types::*;
-    use crate::db::enums::*;
-
-    spatial_ref_sys (srid) {
-        srid -> Int4,
-        auth_name -> Nullable<Varchar>,
-        auth_srid -> Nullable<Int4>,
-        srtext -> Nullable<Varchar>,
-        proj4text -> Nullable<Varchar>,
-    }
-}
-
-allow_tables_to_appear_in_same_query!(access_keys, spatial_ref_sys,);


### PR DESCRIPTION
@frol and I noticed that insertion in remote database was very slow. We investigated and fired an issue in corresponded crate https://github.com/adwhit/diesel-derive-enum/issues/52 

Fixes for that should arrive with `2.0.0` version of `diesel`. Currently we made a hack to speed things up. 

Also, I moved the ExecutionOutcome handling code below the code that handles Receipts. This should cover the case when ExecutionOutcome and the corresponding Receipt came in the same block.