### PR TITLE
refacor: Try to set record status immediately (in case of local receipts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0
+## 1.1.1
 
 * Update NEAR Indexer framework dependency to newer commit hash
 * Add `From` trait to `db::enums::ExecutionStatus` from `near_primitives::views::ExecutionStatusView`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.1.0
 
+* Update NEAR Indexer framework dependency to newer commit hash
+* Add `From` trait to `db::enums::ExecutionStatus` from `near_primitives::views::ExecutionStatusView`
+* Update `db::access_keys::AccessKey::from_receipt_view` with optional arg `status` to be able to set status of the record at once (useful for local receipts)
+* Add warning to `update_receipt_status` to keep track on what is going on there
+* Refactor `handle_outcomes` a bit to use `From` trait for `ExecutionStatus` and clean the code a little bit
+
+## 1.1.0
+
 * Update dependency of NEAR Indexer framework to version `0.2.0` 
 * Handle `local_receipts`
 * Update handling `ExecutionOutcome` according to changes in `0.2.0` NEAR Indexer framework 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,15 +41,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-codec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project",
+ "tokio",
+ "tokio-util 0.3.1",
+]
+
+[[package]]
 name = "actix-connect"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c95cc9569221e9802bf4c377f6c18b90ef10227d787611decf79fd47d2a8e76c"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
  "actix-rt",
  "actix-service",
- "actix-utils",
+ "actix-utils 1.0.6",
  "derive_more",
  "either",
  "futures",
@@ -79,13 +95,13 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c16664cc4fdea8030837ad5a845eb231fb93fc3c5c171edfefb52fad92ce9019"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
  "actix-connect",
  "actix-rt",
  "actix-service",
  "actix-threadpool",
  "actix-tls",
- "actix-utils",
+ "actix-utils 1.0.6",
  "base64 0.11.0",
  "bitflags",
  "brotli2",
@@ -133,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7a10ca4d94e8c8e7a87c5173aba1b97ba9a6563ca02b0e1cd23531093d3ec8"
+checksum = "bbd1f7dbda1645bf7da33554db60891755f6c01c1b2169e2f4c492098d30c235"
 dependencies = [
  "bytestring",
  "http",
@@ -161,14 +177,14 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d74b464215a473c973a2d7d03a69cc10f4ce1f4b38a7659c5193dc5c675630"
+checksum = "45407e6e672ca24784baa667c5d32ef109ccdd8d5e0b5ebb9ef8a67f4dfb708e"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.3.0",
  "actix-rt",
  "actix-service",
- "actix-utils",
+ "actix-utils 2.0.0",
  "futures-channel",
  "futures-util",
  "log",
@@ -224,10 +240,10 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e5b4faaf105e9a6d389c606c298dcdb033061b00d532af9df56ff3a54995a8"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
  "actix-rt",
  "actix-service",
- "actix-utils",
+ "actix-utils 1.0.6",
  "derive_more",
  "either",
  "futures",
@@ -242,7 +258,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf8f5631bf01adec2267808f00e228b761c60c0584cc9fa0b5364f41d147f4e"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
  "actix-rt",
  "actix-service",
  "bitflags",
@@ -255,12 +271,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-utils"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9022dec56632d1d7979e59af14f0597a28a830a9c1c7fec8b2327eb9f16b5a"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-rt",
+ "actix-service",
+ "bitflags",
+ "bytes",
+ "either",
+ "futures-channel",
+ "futures-sink",
+ "futures-util",
+ "log",
+ "pin-project",
+ "slab",
+]
+
+[[package]]
 name = "actix-web"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3158e822461040822f0dbf1735b9c2ce1f95f93b651d7a7aded00b1efbb1f635"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
  "actix-http",
  "actix-macros",
  "actix-router",
@@ -270,7 +306,7 @@ dependencies = [
  "actix-testing",
  "actix-threadpool",
  "actix-tls",
- "actix-utils",
+ "actix-utils 1.0.6",
  "actix-web-codegen",
  "awc",
  "bytes",
@@ -413,7 +449,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7601d4d1d7ef2335d6597a41b5fe069f6ab799b85f53565ab390e7b7065aac5"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
  "actix-http",
  "actix-rt",
  "actix-service",
@@ -684,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 dependencies = [
  "jobserver",
 ]
@@ -708,14 +744,16 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+checksum = "d021fddb7bd3e734370acfa4a83f34095571d8570c039f1420d77540f68d5772"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -739,16 +777,16 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
  "atty",
  "bitflags",
@@ -758,16 +796,16 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.12.1",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -894,7 +932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.2.3",
+ "subtle 2.3.0",
 ]
 
 [[package]]
@@ -906,15 +944,15 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "rand_core 0.5.1",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "zeroize",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.9"
+version = "0.99.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
+checksum = "1dcfabdab475c16a93d669dddfc393027803e347d09663f524447f642fbb84ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1067,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elastic-array"
@@ -1358,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1446,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
@@ -1526,9 +1564,12 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "iovec"
@@ -1632,9 +1673,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "libloading"
@@ -1744,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -1759,11 +1800,12 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
 dependencies = [
  "adler",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1833,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "near-actix-utils"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix",
 ]
@@ -1841,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "borsh",
  "cached",
@@ -1869,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "chrono",
  "derive_more",
@@ -1885,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix",
  "borsh",
@@ -1907,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix",
  "ansi_term 0.11.0",
@@ -1941,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "arrayref",
  "blake2",
@@ -1949,6 +1991,7 @@ dependencies = [
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
+ "derive_more",
  "digest 0.8.1",
  "ed25519-dalek",
  "lazy_static",
@@ -1959,13 +2002,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "subtle 2.2.3",
+ "subtle 2.3.0",
+ "thiserror",
 ]
 
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "borsh",
  "cached",
@@ -1986,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix",
  "futures",
@@ -2002,11 +2046,11 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-for-wallet"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "actix",
  "bigdecimal",
- "clap 3.0.0-beta.1",
+ "clap 3.0.0-beta.2",
  "diesel",
  "diesel-derive-enum",
  "dotenv",
@@ -2028,8 +2072,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+version = "0.2.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2055,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix-web",
  "futures",
@@ -2068,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "lazy_static",
  "log",
@@ -2078,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix",
  "borsh",
@@ -2107,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -2118,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "base64 0.11.0",
  "borsh",
@@ -2149,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2160,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -2173,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "near-primitives",
  "near-runtime-fees",
@@ -2184,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-fees"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "num-rational",
  "serde",
@@ -2193,12 +2237,12 @@ dependencies = [
 [[package]]
 name = "near-runtime-utils"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 
 [[package]]
 name = "near-store"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2220,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix",
  "actix-web",
@@ -2234,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "borsh",
  "near-rpc-error-macro",
@@ -2244,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "base64 0.11.0",
  "bs58",
@@ -2260,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "cached",
  "near-runtime-fees",
@@ -2275,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "neard"
 version = "1.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "actix",
  "actix-web",
@@ -2316,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2341,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=8bf9b050e1173aad3d5cdc31de00f3abfb4a0718#8bf9b050e1173aad3d5cdc31de00f3abfb4a0718"
+source = "git+https://github.com/nearprotocol/nearcore?rev=0501c800cbbb7881f408fe929a95d6c9a95ff657#0501c800cbbb7881f408fe929a95d6c9a95ff657"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2480,9 +2524,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.10.2+1.1.1g"
+version = "111.11.0+1.1.1h"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
+checksum = "380fe324132bea01f45239fadfec9343adb044615f29930d039bec1ae7b9fa5b"
 dependencies = [
  "cc",
 ]
@@ -2608,18 +2652,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+checksum = "f48fad7cfbff853437be7cf54d7b993af21f53be7f0988cbfe4a51535aa77205"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+checksum = "24c6d293bdd3ca5a1697997854c6cf7855e43fb6a0ba1c47af57a5bcafd158ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2628,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+checksum = "71f349a4f0e70676ffb2dbafe16d0c992382d02f0a952e3ddf584fc289dac6b3"
 
 [[package]]
 name = "pin-utils"
@@ -2671,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -2684,14 +2728,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.12"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
@@ -2709,9 +2751,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
 dependencies = [
  "unicode-xid",
 ]
@@ -2919,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
+checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -3080,9 +3122,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
@@ -3108,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3222,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3300,30 +3342,19 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3372,6 +3403,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]
@@ -3542,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
 ]
@@ -3562,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
  "tracing-core",
@@ -3572,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
+checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3917,6 +3957,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ tracing-subscriber = "0.2.4"
 
 # Using these dependencies to introduce dump-state command that will replace data in DB with AccessKeys from a current state
 # this can be refactored once nearcore is divided to components and `state-viewer` of nearcore is made as lib
-near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="8bf9b050e1173aad3d5cdc31de00f3abfb4a0718" }
-near-store = { git = "https://github.com/nearprotocol/nearcore", rev="8bf9b050e1173aad3d5cdc31de00f3abfb4a0718" }
-near-chain = { git = "https://github.com/nearprotocol/nearcore", rev="8bf9b050e1173aad3d5cdc31de00f3abfb4a0718" }
-neard = { git = "https://github.com/nearprotocol/nearcore", rev="8bf9b050e1173aad3d5cdc31de00f3abfb4a0718" }
-near-chain-configs = { git = "https://github.com/nearprotocol/nearcore", rev="8bf9b050e1173aad3d5cdc31de00f3abfb4a0718" }
+near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="0501c800cbbb7881f408fe929a95d6c9a95ff657" }
+near-store = { git = "https://github.com/nearprotocol/nearcore", rev="0501c800cbbb7881f408fe929a95d6c9a95ff657" }
+near-chain = { git = "https://github.com/nearprotocol/nearcore", rev="0501c800cbbb7881f408fe929a95d6c9a95ff657" }
+neard = { git = "https://github.com/nearprotocol/nearcore", rev="0501c800cbbb7881f408fe929a95d6c9a95ff657" }
+near-chain-configs = { git = "https://github.com/nearprotocol/nearcore", rev="0501c800cbbb7881f408fe929a95d6c9a95ff657" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-indexer-for-wallet"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/src/db/access_keys.rs
+++ b/src/db/access_keys.rs
@@ -18,6 +18,7 @@ impl AccessKey {
     pub fn from_receipt_view(
         receipt: &near_indexer::near_primitives::views::ReceiptView,
         block_height: u64,
+        status: Option<ExecutionStatus>,
     ) -> Vec<Self> {
         let mut access_keys: Vec<Self> = vec![];
         if let near_indexer::near_primitives::views::ReceiptEnumView::Action { actions, .. } =
@@ -32,7 +33,7 @@ impl AccessKey {
                         public_key: public_key.to_string(),
                         account_id: receipt.receiver_id.to_string(),
                         action: AccessKeyAction::Add,
-                        status: ExecutionStatus::Pending,
+                        status: status.unwrap_or_else(|| ExecutionStatus::Pending),
                         receipt_hash: receipt.receipt_id.to_string(),
                         block_height: block_height.into(),
                         permission: (&access_key.permission).into(),
@@ -42,7 +43,7 @@ impl AccessKey {
                             public_key: public_key.to_string(),
                             account_id: receipt.receiver_id.to_string(),
                             action: AccessKeyAction::Delete,
-                            status: ExecutionStatus::Pending,
+                            status: status.unwrap_or_else(|| ExecutionStatus::Pending),
                             receipt_hash: receipt.receipt_id.to_string(),
                             block_height: block_height.into(),
                             permission: AccessKeyPermission::NotApplicable,

--- a/src/db/enums.rs
+++ b/src/db/enums.rs
@@ -21,6 +21,18 @@ pub enum ExecutionStatus {
     Failed,
 }
 
+impl From<near_primitives::views::ExecutionStatusView> for ExecutionStatus {
+    fn from(status_view: near_primitives::views::ExecutionStatusView) -> Self {
+        match status_view {
+            // Assume Unknown status as Failed for indexer
+            near_primitives::views::ExecutionStatusView::Failure(_)
+            | near_primitives::views::ExecutionStatusView::Unknown => Self::Failed,
+            near_primitives::views::ExecutionStatusView::SuccessReceiptId(_)
+            | near_primitives::views::ExecutionStatusView::SuccessValue(_) => Self::Success,
+        }
+    }
+}
+
 #[derive(Debug, DbEnum, Clone)]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 #[DieselType = "Access_key_permission_type"]

--- a/src/state_viewer.rs
+++ b/src/state_viewer.rs
@@ -30,7 +30,7 @@ pub(crate) fn load_trie_stop_at_height(
     let runtime = NightshadeRuntime::new(
         &home_dir,
         store,
-        Arc::clone(&near_config.genesis),
+        &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
     );


### PR DESCRIPTION
## 1.1.0

* Update NEAR Indexer framework dependency to newer commit hash
* Add `From` trait to `db::enums::ExecutionStatus` from `near_primitives::views::ExecutionStatusView`
* Update `db::access_keys::AccessKey::from_receipt_view` with optional arg `status` to be able to set status of the record at once (useful for local receipts)
* Add warning to `update_receipt_status` to keep track on what is going on there
* Refactor `handle_outcomes` a bit to use `From` trait for `ExecutionStatus` and clean the code a little bit